### PR TITLE
Fix metric name collisions and cmk-validate-plugins errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: All metric names are now prefixed with `oposs_zpool_` (e.g. `read_ops` -> `oposs_zpool_read_ops`, `free` -> `oposs_zpool_free`) to avoid collisions with built-in metrics introduced in Checkmk 3.0 (e.g. `cmk.plugins.collection.graphing.standalone:metric_read_ops`). This caused "plug-in 'read_ops' already defined" errors on Checkmk 3.0. Existing graphs and RRD history for the old metric names are not carried over.
 
 ### Fixed
+- `cmk-validate-plugins` validation error: `check_default_parameters` used plain `None` for level parameters, which the `SimpleLevels` form spec in the referenced ruleset cannot transform. Defaults now use the proper SimpleLevels consumer model (`('fixed', (warn, crit))` / `('no_levels', None)`), and the check function treats `('no_levels', None)` as "no thresholds configured" instead of evaluating it as truthy fixed levels.
 - Fixed compatibility with Checkmk 3.0: "plug-in '...' already defined" errors during `cmk-update-config` / upgrade caused by unprefixed metric names colliding with new built-in metrics
 
 ## 0.2.1 - 2025-09-02

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **BREAKING**: All metric names are now prefixed with `oposs_zpool_` (e.g. `read_ops` -> `oposs_zpool_read_ops`, `free` -> `oposs_zpool_free`) to avoid collisions with built-in metrics introduced in Checkmk 3.0 (e.g. `cmk.plugins.collection.graphing.standalone:metric_read_ops`). This caused "plug-in 'read_ops' already defined" errors on Checkmk 3.0. Existing graphs and RRD history for the old metric names are not carried over.
+- **BREAKING**: Graph and perfometer names are now prefixed with `oposs_zpool_` as well (e.g. `zpool_capacity` -> `oposs_zpool_capacity`). These live in the same global registry as metric names and are exposed to the same collision risk, so they are renamed in the same breaking change rather than in a later one.
+- Documentation (`README.md`, checkman page) updated to the prefixed metric names, the `_s` seconds suffix on wait times, and the `oposs_zpool_rebuild*` metrics that were previously undocumented.
 
 ### Fixed
+- Checkman page listed two metrics that the check never emits (`trimq_read_pend`, `trimq_read_activ`); the actual metrics are `oposs_zpool_trimq_write_pend` and `oposs_zpool_trimq_write_activ`.
 - `cmk-validate-plugins` validation error: `check_default_parameters` used plain `None` for level parameters, which the `SimpleLevels` form spec in the referenced ruleset cannot transform. Defaults now use the proper SimpleLevels consumer model (`('fixed', (warn, crit))` / `('no_levels', None)`), and the check function treats `('no_levels', None)` as "no thresholds configured" instead of evaluating it as truthy fixed levels.
 - Fixed compatibility with Checkmk 3.0: "plug-in '...' already defined" errors during `cmk-update-config` / upgrade caused by unprefixed metric names colliding with new built-in metrics
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### New
 
 ### Changed
+- **BREAKING**: All metric names are now prefixed with `oposs_zpool_` (e.g. `read_ops` -> `oposs_zpool_read_ops`, `free` -> `oposs_zpool_free`) to avoid collisions with built-in metrics introduced in Checkmk 3.0 (e.g. `cmk.plugins.collection.graphing.standalone:metric_read_ops`). This caused "plug-in 'read_ops' already defined" errors on Checkmk 3.0. Existing graphs and RRD history for the old metric names are not carried over.
 
 ### Fixed
+- Fixed compatibility with Checkmk 3.0: "plug-in '...' already defined" errors during `cmk-update-config` / upgrade caused by unprefixed metric names colliding with new built-in metrics
 
 ## 0.2.1 - 2025-09-02
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -77,18 +77,24 @@ Configure monitoring thresholds in CheckMK under "Host & Service Parameters" > "
 
 ## Metrics
 
+All metric names carry the `oposs_zpool_` prefix. This avoids collisions with
+the built-in CheckMK metrics of the same base name (`read_ops`, `free`, ...).
+Wait times are stored in seconds and carry an `_s` suffix; the corresponding
+thresholds are configured in milliseconds.
+
 ### Basic Metrics
-- `read_ops`, `write_ops` - Operations per second
-- `read_throughput`, `write_throughput` - Bytes per second
-- `read_wait`, `write_wait` - I/O wait times in milliseconds
-- `storage_used_percent` - Pool utilization percentage
-- `allocated`, `free` - Pool space allocation
+- `oposs_zpool_read_ops`, `oposs_zpool_write_ops` - Operations per second
+- `oposs_zpool_read_throughput`, `oposs_zpool_write_throughput` - Bytes per second
+- `oposs_zpool_read_wait_s`, `oposs_zpool_write_wait_s` - I/O wait times in seconds
+- `oposs_zpool_storage_used_percent` - Pool utilization percentage
+- `oposs_zpool_allocated`, `oposs_zpool_free` - Pool space allocation
 
 ### Advanced Metrics
-- `disk_read_wait`, `disk_write_wait` - Disk-level wait times
-- `syncq_*_wait`, `asyncq_*_wait` - Queue-specific wait times
-- `scrub_wait`, `trim_wait` - Maintenance operation wait times
-- `*_pend`, `*_activ` - Queue depths (pending/active operations)
+- `oposs_zpool_disk_read_wait_s`, `oposs_zpool_disk_write_wait_s` - Disk-level wait times
+- `oposs_zpool_disk_wait_max_s` - Higher of the two disk wait times (only emitted when disk wait levels are configured)
+- `oposs_zpool_syncq_*_wait_s`, `oposs_zpool_asyncq_*_wait_s` - Queue-specific wait times
+- `oposs_zpool_scrub_wait_s`, `oposs_zpool_trim_wait_s`, `oposs_zpool_rebuild_wait_s` - Maintenance operation wait times
+- `oposs_zpool_*_pend`, `oposs_zpool_*_activ` - Queue depths (pending/active operations)
 
 ## Requirements
 

--- a/local/lib/python3/cmk_addons/plugins/oposs_zpool_iostat/agent_based/oposs_zpool_iostat.py
+++ b/local/lib/python3/cmk_addons/plugins/oposs_zpool_iostat/agent_based/oposs_zpool_iostat.py
@@ -250,7 +250,7 @@ def check_oposs_zpool_iostat(
         yield from check_levels(
             used_percent,
             levels_upper=levels_upper,
-            metric_name="storage_used_percent",
+            metric_name="oposs_zpool_storage_used_percent",
             label="Storage utilization",
             boundaries=(0.0, 100.0),
             render_func=render.percent,
@@ -262,24 +262,24 @@ def check_oposs_zpool_iostat(
         yield from check_levels(
             read_ops,
             levels_upper=read_ops_levels,
-            metric_name="read_ops",
+            metric_name="oposs_zpool_read_ops",
             label="Read operations",
             render_func=_render_operations_per_second,
         )
     else:
-        yield Metric("read_ops", read_ops)
+        yield Metric("oposs_zpool_read_ops", read_ops)
     
     write_ops_levels = params.get('write_ops_levels')
     if write_ops_levels:
         yield from check_levels(
             write_ops,
             levels_upper=write_ops_levels,
-            metric_name="write_ops", 
+            metric_name="oposs_zpool_write_ops", 
             label="Write operations",
             render_func=_render_operations_per_second,
         )
     else:
-        yield Metric("write_ops", write_ops)
+        yield Metric("oposs_zpool_write_ops", write_ops)
     
     # Throughput metrics and levels
     read_throughput_levels = params.get('read_throughput_levels')
@@ -287,41 +287,41 @@ def check_oposs_zpool_iostat(
         yield from check_levels(
             read_bytes,
             levels_upper=read_throughput_levels,
-            metric_name="read_throughput",
+            metric_name="oposs_zpool_read_throughput",
             label="Read throughput",
             render_func=render.bytes,
         )
     else:
-        yield Metric("read_throughput", read_bytes)
+        yield Metric("oposs_zpool_read_throughput", read_bytes)
         
     write_throughput_levels = params.get('write_throughput_levels')
     if write_throughput_levels:
         yield from check_levels(
             write_bytes,
             levels_upper=write_throughput_levels,
-            metric_name="write_throughput",
+            metric_name="oposs_zpool_write_throughput",
             label="Write throughput",
             render_func=render.bytes,
         )
     else:
-        yield Metric("write_throughput", write_bytes)
+        yield Metric("oposs_zpool_write_throughput", write_bytes)
     
     # Storage metrics
-    yield Metric("allocated", alloc)
-    yield Metric("free", free)
+    yield Metric("oposs_zpool_allocated", alloc)
+    yield Metric("oposs_zpool_free", free)
     
     # Wait time metrics and levels
     yield from _check_wait_time_metric(
         pool_data.get('read_wait'),
         params.get('read_wait_levels'),
-        "read_wait",
+        "oposs_zpool_read_wait",
         "Read wait time"
     )
     
     yield from _check_wait_time_metric(
         pool_data.get('write_wait'),
         params.get('write_wait_levels'),
-        "write_wait",
+        "oposs_zpool_write_wait",
         "Write wait time"
     )
     
@@ -329,14 +329,14 @@ def check_oposs_zpool_iostat(
     yield from _check_wait_time_metric(
         pool_data.get('disk_read_wait'),
         None,  # No individual levels for disk_read_wait
-        "disk_read_wait",
+        "oposs_zpool_disk_read_wait",
         "Disk read wait time"
     )
     
     yield from _check_wait_time_metric(
         pool_data.get('disk_write_wait'),
         None,  # No individual levels for disk_write_wait
-        "disk_write_wait",
+        "oposs_zpool_disk_write_wait",
         "Disk write wait time"
     )
     
@@ -354,7 +354,7 @@ def check_oposs_zpool_iostat(
                 yield from _check_wait_time_metric(
                     max_disk_wait_ns,
                     params.get('disk_wait_levels'),
-                    "disk_wait_max",
+                    "oposs_zpool_disk_wait_max",
                     "Disk wait time"
                 )
     
@@ -370,10 +370,12 @@ def check_oposs_zpool_iostat(
     ]
     
     for metric_name, param_name, label in queue_wait_metrics:
+        # JSON key stays unprefixed; metric name gets the oposs_zpool_ prefix
+        # (applied inside _check_wait_time_metric, which appends "_s").
         yield from _check_wait_time_metric(
             pool_data.get(metric_name),
             params.get(param_name),
-            metric_name,
+            "oposs_zpool_" + metric_name,
             label
         )
     
@@ -397,23 +399,26 @@ def check_oposs_zpool_iostat(
     
     for metric_name, param_name in queue_depth_metrics:
         value = pool_data.get(metric_name)
-        
+        # Prefix metric name to avoid collisions with Checkmk built-in metrics;
+        # the JSON key from the agent stays unprefixed.
+        prefixed_metric_name = "oposs_zpool_" + metric_name
+
         # Always yield metric, even if NaN (for graph display)
         if value is None:
-            yield Metric(metric_name, float('nan'))
+            yield Metric(prefixed_metric_name, float('nan'))
             continue
-            
+
         levels_param = params.get(param_name)
         if levels_param:
             yield from check_levels(
                 value,
                 levels_upper=levels_param,
-                metric_name=metric_name,
+                metric_name=prefixed_metric_name,
                 label=metric_name.replace('_', ' ').title(),
                 render_func=_render_count,
             )
         else:
-            yield Metric(metric_name, value)
+            yield Metric(prefixed_metric_name, value)
 
 # Create the check plugin
 check_plugin_oposs_zpool_iostat = CheckPlugin(

--- a/local/lib/python3/cmk_addons/plugins/oposs_zpool_iostat/agent_based/oposs_zpool_iostat.py
+++ b/local/lib/python3/cmk_addons/plugins/oposs_zpool_iostat/agent_based/oposs_zpool_iostat.py
@@ -41,6 +41,21 @@ def _render_count(value: float) -> str:
     """Render value as count with no decimal places."""
     return f"{value:.0f}"
 
+def _levels_active(levels_param) -> bool:
+    """Return True when a SimpleLevels param actually configures thresholds.
+
+    SimpleLevels produces ('fixed', (warn, crit)) when thresholds are set and
+    ('no_levels', None) when the user disabled levels. Plain tuples are truthy
+    in both cases, so check for the 'fixed' marker explicitly.
+    """
+    return bool(
+        isinstance(levels_param, tuple)
+        and len(levels_param) == 2
+        and levels_param[0] == "fixed"
+        and levels_param[1] is not None
+    )
+
+
 def _extract_levels(levels_param):
     """
     Extract levels from parameter in various formats.
@@ -108,7 +123,7 @@ def _check_wait_time_metric(
     value_s = value_ns / 1e9 if value_ns != 0 else 0
     
     # Convert levels if configured
-    if levels_param:
+    if _levels_active(levels_param):
         # Convert millisecond thresholds to seconds
         levels_in_seconds = _convert_ms_levels_to_seconds(levels_param)
         yield from check_levels(
@@ -258,7 +273,7 @@ def check_oposs_zpool_iostat(
     
     # I/O Operation metrics and levels
     read_ops_levels = params.get('read_ops_levels')
-    if read_ops_levels:
+    if _levels_active(read_ops_levels):
         yield from check_levels(
             read_ops,
             levels_upper=read_ops_levels,
@@ -270,7 +285,7 @@ def check_oposs_zpool_iostat(
         yield Metric("oposs_zpool_read_ops", read_ops)
     
     write_ops_levels = params.get('write_ops_levels')
-    if write_ops_levels:
+    if _levels_active(write_ops_levels):
         yield from check_levels(
             write_ops,
             levels_upper=write_ops_levels,
@@ -283,7 +298,7 @@ def check_oposs_zpool_iostat(
     
     # Throughput metrics and levels
     read_throughput_levels = params.get('read_throughput_levels')
-    if read_throughput_levels:
+    if _levels_active(read_throughput_levels):
         yield from check_levels(
             read_bytes,
             levels_upper=read_throughput_levels,
@@ -295,7 +310,7 @@ def check_oposs_zpool_iostat(
         yield Metric("oposs_zpool_read_throughput", read_bytes)
         
     write_throughput_levels = params.get('write_throughput_levels')
-    if write_throughput_levels:
+    if _levels_active(write_throughput_levels):
         yield from check_levels(
             write_bytes,
             levels_upper=write_throughput_levels,
@@ -342,7 +357,7 @@ def check_oposs_zpool_iostat(
     
     # Check combined disk wait levels if configured
     disk_wait_levels = params.get('disk_wait_levels')
-    if disk_wait_levels:
+    if _levels_active(disk_wait_levels):
         disk_read_wait_ns = pool_data.get('disk_read_wait')
         disk_write_wait_ns = pool_data.get('disk_write_wait')
         
@@ -409,7 +424,7 @@ def check_oposs_zpool_iostat(
             continue
 
         levels_param = params.get(param_name)
-        if levels_param:
+        if _levels_active(levels_param):
             yield from check_levels(
                 value,
                 levels_upper=levels_param,
@@ -429,36 +444,38 @@ check_plugin_oposs_zpool_iostat = CheckPlugin(
     check_function=check_oposs_zpool_iostat,
     check_ruleset_name="oposs_zpool_iostat",
     check_default_parameters={
+        # SimpleLevels consumer model: ('fixed', (warn, crit)) or
+        # ('no_levels', None). Plain None is rejected by cmk-validate-plugins.
         'storage_levels': ('fixed', (80.0, 90.0)),  # Default storage usage levels
-        'read_ops_levels': None,
-        'write_ops_levels': None,
-        'read_wait_levels': None,
-        'write_wait_levels': None,
-        'read_throughput_levels': None,
-        'write_throughput_levels': None,
-        'disk_wait_levels': None,
+        'read_ops_levels': ('no_levels', None),
+        'write_ops_levels': ('no_levels', None),
+        'read_wait_levels': ('no_levels', None),
+        'write_wait_levels': ('no_levels', None),
+        'read_throughput_levels': ('no_levels', None),
+        'write_throughput_levels': ('no_levels', None),
+        'disk_wait_levels': ('no_levels', None),
         # Individual queue wait time levels
-        'syncq_read_wait_levels': None,
-        'syncq_write_wait_levels': None,
-        'asyncq_read_wait_levels': None,
-        'asyncq_write_wait_levels': None,
-        'scrub_wait_levels': None,
-        'trim_wait_levels': None,
-        'rebuild_wait_levels': None,
+        'syncq_read_wait_levels': ('no_levels', None),
+        'syncq_write_wait_levels': ('no_levels', None),
+        'asyncq_read_wait_levels': ('no_levels', None),
+        'asyncq_write_wait_levels': ('no_levels', None),
+        'scrub_wait_levels': ('no_levels', None),
+        'trim_wait_levels': ('no_levels', None),
+        'rebuild_wait_levels': ('no_levels', None),
         # Individual queue depth levels
-        'syncq_read_pend_levels': None,
-        'syncq_read_activ_levels': None,
-        'syncq_write_pend_levels': None,
-        'syncq_write_activ_levels': None,
-        'asyncq_read_pend_levels': None,
-        'asyncq_read_activ_levels': None,
-        'asyncq_write_pend_levels': None,
-        'asyncq_write_activ_levels': None,
-        'scrubq_read_pend_levels': None,
-        'scrubq_read_activ_levels': None,
-        'trimq_write_pend_levels': None,
-        'trimq_write_activ_levels': None,
-        'rebuildq_write_pend_levels': None,
-        'rebuildq_write_activ_levels': None,
+        'syncq_read_pend_levels': ('no_levels', None),
+        'syncq_read_activ_levels': ('no_levels', None),
+        'syncq_write_pend_levels': ('no_levels', None),
+        'syncq_write_activ_levels': ('no_levels', None),
+        'asyncq_read_pend_levels': ('no_levels', None),
+        'asyncq_read_activ_levels': ('no_levels', None),
+        'asyncq_write_pend_levels': ('no_levels', None),
+        'asyncq_write_activ_levels': ('no_levels', None),
+        'scrubq_read_pend_levels': ('no_levels', None),
+        'scrubq_read_activ_levels': ('no_levels', None),
+        'trimq_write_pend_levels': ('no_levels', None),
+        'trimq_write_activ_levels': ('no_levels', None),
+        'rebuildq_write_pend_levels': ('no_levels', None),
+        'rebuildq_write_activ_levels': ('no_levels', None),
     },
 )

--- a/local/lib/python3/cmk_addons/plugins/oposs_zpool_iostat/checkman/oposs_zpool_iostat
+++ b/local/lib/python3/cmk_addons/plugins/oposs_zpool_iostat/checkman/oposs_zpool_iostat
@@ -56,46 +56,56 @@ discovery:
 perfdata:
  The check provides comprehensive performance data including:
 
+ All metric names carry the {oposs_zpool_} prefix. This avoids collisions
+ with the built-in CheckMK metrics of the same base name. Wait times are
+ stored in seconds and carry an {_s} suffix, while the corresponding
+ thresholds are configured in milliseconds.
+
  Basic I/O metrics:
- - {read_ops} - Read operations per second
- - {write_ops} - Write operations per second
- - {read_throughput} - Read throughput in bytes per second
- - {write_throughput} - Write throughput in bytes per second
+ - {oposs_zpool_read_ops} - Read operations per second
+ - {oposs_zpool_write_ops} - Write operations per second
+ - {oposs_zpool_read_throughput} - Read throughput in bytes per second
+ - {oposs_zpool_write_throughput} - Write throughput in bytes per second
 
  Storage capacity:
- - {allocated} - Allocated storage space in bytes
- - {free} - Free storage space in bytes
- - {storage_used_percent} - Storage utilization percentage
+ - {oposs_zpool_allocated} - Allocated storage space in bytes
+ - {oposs_zpool_free} - Free storage space in bytes
+ - {oposs_zpool_storage_used_percent} - Storage utilization percentage
 
  Latency metrics:
- - {read_wait} - Average read I/O wait time in milliseconds
- - {write_wait} - Average write I/O wait time in milliseconds
- - {disk_read_wait} - Disk-level read wait time
- - {disk_write_wait} - Disk-level write wait time
+ - {oposs_zpool_read_wait_s} - Average read I/O wait time in seconds
+ - {oposs_zpool_write_wait_s} - Average write I/O wait time in seconds
+ - {oposs_zpool_disk_read_wait_s} - Disk-level read wait time
+ - {oposs_zpool_disk_write_wait_s} - Disk-level write wait time
+ - {oposs_zpool_disk_wait_max_s} - Higher of the two disk wait times, only
+   emitted when disk wait levels are configured
 
  Queue statistics (when available):
- - {syncq_read_wait} - Synchronous read queue wait time
- - {syncq_write_wait} - Synchronous write queue wait time
- - {asyncq_read_wait} - Asynchronous read queue wait time
- - {asyncq_write_wait} - Asynchronous write queue wait time
- - {scrub_wait} - Scrub operation wait time
- - {trim_wait} - Trim operation wait time
+ - {oposs_zpool_syncq_read_wait_s} - Synchronous read queue wait time
+ - {oposs_zpool_syncq_write_wait_s} - Synchronous write queue wait time
+ - {oposs_zpool_asyncq_read_wait_s} - Asynchronous read queue wait time
+ - {oposs_zpool_asyncq_write_wait_s} - Asynchronous write queue wait time
+ - {oposs_zpool_scrub_wait_s} - Scrub operation wait time
+ - {oposs_zpool_trim_wait_s} - Trim operation wait time
+ - {oposs_zpool_rebuild_wait_s} - Rebuild operation wait time
 
  Queue depths:
- - {syncq_read_pend} - Pending synchronous read operations
- - {syncq_read_activ} - Active synchronous read operations
- - {syncq_write_pend} - Pending synchronous write operations
- - {syncq_write_activ} - Active synchronous write operations
- - {asyncq_read_pend} - Pending asynchronous read operations
- - {asyncq_read_activ} - Active asynchronous read operations
- - {asyncq_write_pend} - Pending asynchronous write operations
- - {asyncq_write_activ} - Active asynchronous write operations
+ - {oposs_zpool_syncq_read_pend} - Pending synchronous read operations
+ - {oposs_zpool_syncq_read_activ} - Active synchronous read operations
+ - {oposs_zpool_syncq_write_pend} - Pending synchronous write operations
+ - {oposs_zpool_syncq_write_activ} - Active synchronous write operations
+ - {oposs_zpool_asyncq_read_pend} - Pending asynchronous read operations
+ - {oposs_zpool_asyncq_read_activ} - Active asynchronous read operations
+ - {oposs_zpool_asyncq_write_pend} - Pending asynchronous write operations
+ - {oposs_zpool_asyncq_write_activ} - Active asynchronous write operations
 
  Special operation queues:
- - {scrubq_read_pend} - Pending scrub read operations
- - {scrubq_read_activ} - Active scrub read operations
- - {trimq_read_pend} - Pending trim read operations
- - {trimq_read_activ} - Active trim read operations
+ - {oposs_zpool_scrubq_read_pend} - Pending scrub read operations
+ - {oposs_zpool_scrubq_read_activ} - Active scrub read operations
+ - {oposs_zpool_trimq_write_pend} - Pending trim write operations
+ - {oposs_zpool_trimq_write_activ} - Active trim write operations
+ - {oposs_zpool_rebuildq_write_pend} - Pending rebuild write operations
+ - {oposs_zpool_rebuildq_write_activ} - Active rebuild write operations
 
 parameters:
  Storage utilization levels:
@@ -123,6 +133,7 @@ parameters:
  - {asyncq_write_wait_levels} - Thresholds for asynchronous write queue wait times
  - {scrub_wait_levels} - Thresholds for scrub operation wait times
  - {trim_wait_levels} - Thresholds for trim operation wait times
+ - {rebuild_wait_levels} - Thresholds for rebuild operation wait times
 
  Queue depth monitoring:
  - {syncq_read_pend_levels} - Thresholds for pending synchronous read operations
@@ -135,8 +146,10 @@ parameters:
  - {asyncq_write_activ_levels} - Thresholds for active asynchronous write operations
  - {scrubq_read_pend_levels} - Thresholds for pending scrub read operations
  - {scrubq_read_activ_levels} - Thresholds for active scrub read operations
- - {trimq_read_pend_levels} - Thresholds for pending trim read operations
- - {trimq_read_activ_levels} - Thresholds for active trim read operations
+ - {trimq_write_pend_levels} - Thresholds for pending trim write operations
+ - {trimq_write_activ_levels} - Thresholds for active trim write operations
+ - {rebuildq_write_pend_levels} - Thresholds for pending rebuild write operations
+ - {rebuildq_write_activ_levels} - Thresholds for active rebuild write operations
 
 cluster:
  In cluster environments, the check can be configured to monitor ZFS pools

--- a/local/lib/python3/cmk_addons/plugins/oposs_zpool_iostat/graphing/oposs_zpool_iostat.py
+++ b/local/lib/python3/cmk_addons/plugins/oposs_zpool_iostat/graphing/oposs_zpool_iostat.py
@@ -276,7 +276,7 @@ metric_rebuildq_write_activ = Metric(
 
 # 1. Capacity - Storage allocation and usage
 graph_zpool_capacity = Graph(
-    name="zpool_capacity",
+    name="oposs_zpool_capacity",
     title=Title("ZFS Pool Capacity"),
     simple_lines=[
         "oposs_zpool_allocated",
@@ -290,7 +290,7 @@ graph_zpool_capacity = Graph(
 
 # 2. Operations - Read/write operations per second
 graph_zpool_operations = Graph(
-    name="zpool_operations",
+    name="oposs_zpool_operations",
     title=Title("ZFS Pool Operations"),
     simple_lines=[
         "oposs_zpool_read_ops",
@@ -304,15 +304,15 @@ graph_zpool_operations = Graph(
 
 # 3. Bandwidth - Read/write throughput
 graph_zpool_bandwidth = Bidirectional(
-    name="zpool_bandwidth",
+    name="oposs_zpool_bandwidth",
     title=Title("ZFS Pool Bandwidth"),
     lower=Graph(
-        name="zpool_bandwidth_read",
+        name="oposs_zpool_bandwidth_read",
         title=Title("Read Bandwidth"),
         simple_lines=["oposs_zpool_read_throughput"],
     ),
     upper=Graph(
-        name="zpool_bandwidth_write", 
+        name="oposs_zpool_bandwidth_write", 
         title=Title("Write Bandwidth"),
         simple_lines=["oposs_zpool_write_throughput"],
     ),
@@ -321,7 +321,7 @@ graph_zpool_bandwidth = Bidirectional(
 # 4. Wait Times - Combined graph for all working wait time metrics
 
 graph_zpool_wait_times = Graph(
-    name="zpool_wait_times",
+    name="oposs_zpool_wait_times",
     title=Title("ZFS Pool Wait Times"),
     simple_lines=[
         # Total wait times
@@ -364,7 +364,7 @@ graph_zpool_wait_times = Graph(
 # 5. Task Queues - Combined graph for sync and async queues
 
 graph_zpool_queue_depths = Graph(
-    name="zpool_queue_depths",
+    name="oposs_zpool_queue_depths",
     title=Title("ZFS Pool Queue Depths"),
     simple_lines=[
         # Sync queue depths
@@ -412,7 +412,7 @@ graph_zpool_queue_depths = Graph(
 
 # Define perfometers
 perfometer_zpool_operations = Perfometer(
-    name="zpool_operations",
+    name="oposs_zpool_operations",
     focus_range=FocusRange(
         lower=Closed(0),
         upper=Closed(1000),
@@ -424,7 +424,7 @@ perfometer_zpool_operations = Perfometer(
 )
 
 perfometer_zpool_storage = Perfometer(
-    name="zpool_storage",
+    name="oposs_zpool_storage",
     focus_range=FocusRange(
         lower=Closed(0),
         upper=Closed(1000000000000),  # 1TB
@@ -436,7 +436,7 @@ perfometer_zpool_storage = Perfometer(
 )
 
 perfometer_zpool_wait_times = Perfometer(
-    name="zpool_wait_times",
+    name="oposs_zpool_wait_times",
     focus_range=FocusRange(
         lower=Closed(0),
         upper=Closed(0.1),  # 100ms in seconds
@@ -449,9 +449,9 @@ perfometer_zpool_wait_times = Perfometer(
 
 # Stacked perfometer for comprehensive view
 perfometer_zpool_comprehensive = Stacked(
-    name="zpool_comprehensive",
+    name="oposs_zpool_comprehensive",
     lower=Perfometer(
-        name="zpool_ops_lower",
+        name="oposs_zpool_ops_lower",
         focus_range=FocusRange(
             lower=Closed(0),
             upper=Closed(1000),
@@ -459,7 +459,7 @@ perfometer_zpool_comprehensive = Stacked(
         segments=["oposs_zpool_read_ops", "oposs_zpool_write_ops"],
     ),
     upper=Perfometer(
-        name="zpool_storage_upper",
+        name="oposs_zpool_storage_upper",
         focus_range=FocusRange(
             lower=Closed(0),
             upper=Closed(1000000000000),  # 1TB

--- a/local/lib/python3/cmk_addons/plugins/oposs_zpool_iostat/graphing/oposs_zpool_iostat.py
+++ b/local/lib/python3/cmk_addons/plugins/oposs_zpool_iostat/graphing/oposs_zpool_iostat.py
@@ -35,21 +35,21 @@ unit_percent = Unit(DecimalNotation("%"))
 
 # Storage capacity metrics
 metric_allocated = Metric(
-    name="allocated",
+    name="oposs_zpool_allocated",
     title=Title("Allocated space"),
     unit=unit_bytes,
     color=Color.BLUE,
 )
 
 metric_free = Metric(
-    name="free",
+    name="oposs_zpool_free",
     title=Title("Free space"),
     unit=unit_bytes,
     color=Color.GREEN,
 )
 
 metric_storage_used_percent = Metric(
-    name="storage_used_percent",
+    name="oposs_zpool_storage_used_percent",
     title=Title("Storage utilization"),
     unit=unit_percent,
     color=Color.ORANGE,
@@ -57,14 +57,14 @@ metric_storage_used_percent = Metric(
 
 # I/O Operations metrics
 metric_read_ops = Metric(
-    name="read_ops",
+    name="oposs_zpool_read_ops",
     title=Title("Read operations"),
     unit=unit_ops_per_sec,
     color=Color.CYAN,
 )
 
 metric_write_ops = Metric(
-    name="write_ops",
+    name="oposs_zpool_write_ops",
     title=Title("Write operations"),
     unit=unit_ops_per_sec,
     color=Color.PURPLE,
@@ -72,14 +72,14 @@ metric_write_ops = Metric(
 
 # Throughput metrics
 metric_read_throughput = Metric(
-    name="read_throughput",
+    name="oposs_zpool_read_throughput",
     title=Title("Read throughput"),
     unit=unit_bytes_per_sec,
     color=Color.LIGHT_BLUE,
 )
 
 metric_write_throughput = Metric(
-    name="write_throughput",
+    name="oposs_zpool_write_throughput",
     title=Title("Write throughput"),
     unit=unit_bytes_per_sec,
     color=Color.LIGHT_PURPLE,
@@ -87,35 +87,35 @@ metric_write_throughput = Metric(
 
 # Wait time metrics - now in seconds with _s suffix
 metric_read_wait_s = Metric(
-    name="read_wait_s",
+    name="oposs_zpool_read_wait_s",
     title=Title("Read wait time"),
     unit=unit_seconds,
     color=Color.BLUE,
 )
 
 metric_write_wait_s = Metric(
-    name="write_wait_s",
+    name="oposs_zpool_write_wait_s",
     title=Title("Write wait time"),
     unit=unit_seconds,
     color=Color.RED,
 )
 
 metric_disk_read_wait_s = Metric(
-    name="disk_read_wait_s",
+    name="oposs_zpool_disk_read_wait_s",
     title=Title("Disk read wait time"),
     unit=unit_seconds,
     color=Color.CYAN,
 )
 
 metric_disk_write_wait_s = Metric(
-    name="disk_write_wait_s",
+    name="oposs_zpool_disk_write_wait_s",
     title=Title("Disk write wait time"),
     unit=unit_seconds,
     color=Color.ORANGE,
 )
 
 metric_disk_wait_max_s = Metric(
-    name="disk_wait_max_s",
+    name="oposs_zpool_disk_wait_max_s",
     title=Title("Max disk wait time"),
     unit=unit_seconds,
     color=Color.DARK_RED,
@@ -123,28 +123,28 @@ metric_disk_wait_max_s = Metric(
 
 # Queue wait time metrics - now in seconds with _s suffix
 metric_syncq_read_wait_s = Metric(
-    name="syncq_read_wait_s",
+    name="oposs_zpool_syncq_read_wait_s",
     title=Title("Sync queue read wait time"),
     unit=unit_seconds,
     color=Color.GREEN,
 )
 
 metric_syncq_write_wait_s = Metric(
-    name="syncq_write_wait_s",
+    name="oposs_zpool_syncq_write_wait_s",
     title=Title("Sync queue write wait time"),
     unit=unit_seconds,
     color=Color.YELLOW,
 )
 
 metric_asyncq_read_wait_s = Metric(
-    name="asyncq_read_wait_s",
+    name="oposs_zpool_asyncq_read_wait_s",
     title=Title("Async queue read wait time"),
     unit=unit_seconds,
     color=Color.PURPLE,
 )
 
 metric_asyncq_write_wait_s = Metric(
-    name="asyncq_write_wait_s",
+    name="oposs_zpool_asyncq_write_wait_s",
     title=Title("Async queue write wait time"),
     unit=unit_seconds,
     color=Color.PINK,
@@ -152,21 +152,21 @@ metric_asyncq_write_wait_s = Metric(
 
 # Special operation wait times - now in seconds with _s suffix
 metric_scrub_wait_s = Metric(
-    name="scrub_wait_s",
+    name="oposs_zpool_scrub_wait_s",
     title=Title("Scrub wait time"),
     unit=unit_seconds,
     color=Color.BROWN,
 )
 
 metric_trim_wait_s = Metric(
-    name="trim_wait_s",
+    name="oposs_zpool_trim_wait_s",
     title=Title("Trim wait time"),
     unit=unit_seconds,
     color=Color.GRAY,
 )
 
 metric_rebuild_wait_s = Metric(
-    name="rebuild_wait_s",
+    name="oposs_zpool_rebuild_wait_s",
     title=Title("Rebuild wait time"),
     unit=unit_seconds,
     color=Color.PINK,
@@ -174,56 +174,56 @@ metric_rebuild_wait_s = Metric(
 
 # Queue depth metrics (pending operations)
 metric_syncq_read_pend = Metric(
-    name="syncq_read_pend",
+    name="oposs_zpool_syncq_read_pend",
     title=Title("Sync queue read pending"),
     unit=unit_count,
     color=Color.LIGHT_GRAY,
 )
 
 metric_syncq_read_activ = Metric(
-    name="syncq_read_activ",
+    name="oposs_zpool_syncq_read_activ",
     title=Title("Sync queue read active"),
     unit=unit_count,
     color=Color.GRAY,
 )
 
 metric_syncq_write_pend = Metric(
-    name="syncq_write_pend",
+    name="oposs_zpool_syncq_write_pend",
     title=Title("Sync queue write pending"),
     unit=unit_count,
     color=Color.LIGHT_BROWN,
 )
 
 metric_syncq_write_activ = Metric(
-    name="syncq_write_activ",
+    name="oposs_zpool_syncq_write_activ",
     title=Title("Sync queue write active"),
     unit=unit_count,
     color=Color.BROWN,
 )
 
 metric_asyncq_read_pend = Metric(
-    name="asyncq_read_pend",
+    name="oposs_zpool_asyncq_read_pend",
     title=Title("Async queue read pending"),
     unit=unit_count,
     color=Color.LIGHT_CYAN,
 )
 
 metric_asyncq_read_activ = Metric(
-    name="asyncq_read_activ",
+    name="oposs_zpool_asyncq_read_activ",
     title=Title("Async queue read active"),
     unit=unit_count,
     color=Color.DARK_CYAN,
 )
 
 metric_asyncq_write_pend = Metric(
-    name="asyncq_write_pend",
+    name="oposs_zpool_asyncq_write_pend",
     title=Title("Async queue write pending"),
     unit=unit_count,
     color=Color.LIGHT_PINK,
 )
 
 metric_asyncq_write_activ = Metric(
-    name="asyncq_write_activ",
+    name="oposs_zpool_asyncq_write_activ",
     title=Title("Async queue write active"),
     unit=unit_count,
     color=Color.PINK,
@@ -231,42 +231,42 @@ metric_asyncq_write_activ = Metric(
 
 # Special operation queue metrics
 metric_scrubq_read_pend = Metric(
-    name="scrubq_read_pend",
+    name="oposs_zpool_scrubq_read_pend",
     title=Title("Scrub queue read pending"),
     unit=unit_count,
     color=Color.LIGHT_PURPLE,
 )
 
 metric_scrubq_read_activ = Metric(
-    name="scrubq_read_activ",
+    name="oposs_zpool_scrubq_read_activ",
     title=Title("Scrub queue read active"),
     unit=unit_count,
     color=Color.PURPLE,
 )
 
 metric_trimq_write_pend = Metric(
-    name="trimq_write_pend",
+    name="oposs_zpool_trimq_write_pend",
     title=Title("Trim queue write pending"),
     unit=unit_count,
     color=Color.LIGHT_BLUE,
 )
 
 metric_trimq_write_activ = Metric(
-    name="trimq_write_activ",
+    name="oposs_zpool_trimq_write_activ",
     title=Title("Trim queue write active"),
     unit=unit_count,
     color=Color.DARK_BLUE,
 )
 
 metric_rebuildq_write_pend = Metric(
-    name="rebuildq_write_pend",
+    name="oposs_zpool_rebuildq_write_pend",
     title=Title("Rebuild queue write pending"),
     unit=unit_count,
     color=Color.LIGHT_PURPLE,
 )
 
 metric_rebuildq_write_activ = Metric(
-    name="rebuildq_write_activ",
+    name="oposs_zpool_rebuildq_write_activ",
     title=Title("Rebuild queue write active"),
     unit=unit_count,
     color=Color.PURPLE,
@@ -279,8 +279,8 @@ graph_zpool_capacity = Graph(
     name="zpool_capacity",
     title=Title("ZFS Pool Capacity"),
     simple_lines=[
-        "allocated",
-        "free",
+        "oposs_zpool_allocated",
+        "oposs_zpool_free",
     ],
     minimal_range=MinimalRange(
         lower=0,
@@ -293,8 +293,8 @@ graph_zpool_operations = Graph(
     name="zpool_operations",
     title=Title("ZFS Pool Operations"),
     simple_lines=[
-        "read_ops",
-        "write_ops",
+        "oposs_zpool_read_ops",
+        "oposs_zpool_write_ops",
     ],
     minimal_range=MinimalRange(
         lower=0,
@@ -309,12 +309,12 @@ graph_zpool_bandwidth = Bidirectional(
     lower=Graph(
         name="zpool_bandwidth_read",
         title=Title("Read Bandwidth"),
-        simple_lines=["read_throughput"],
+        simple_lines=["oposs_zpool_read_throughput"],
     ),
     upper=Graph(
         name="zpool_bandwidth_write", 
         title=Title("Write Bandwidth"),
-        simple_lines=["write_throughput"],
+        simple_lines=["oposs_zpool_write_throughput"],
     ),
 )
 
@@ -325,35 +325,35 @@ graph_zpool_wait_times = Graph(
     title=Title("ZFS Pool Wait Times"),
     simple_lines=[
         # Total wait times
-        "read_wait_s",
-        "write_wait_s",
+        "oposs_zpool_read_wait_s",
+        "oposs_zpool_write_wait_s",
         # Disk wait times
-        "disk_read_wait_s",
-        "disk_write_wait_s",
+        "oposs_zpool_disk_read_wait_s",
+        "oposs_zpool_disk_write_wait_s",
         # Sync queue wait times
-        "syncq_read_wait_s",
-        "syncq_write_wait_s",
+        "oposs_zpool_syncq_read_wait_s",
+        "oposs_zpool_syncq_write_wait_s",
         # Async queue wait times
-        "asyncq_read_wait_s",
-        "asyncq_write_wait_s",
+        "oposs_zpool_asyncq_read_wait_s",
+        "oposs_zpool_asyncq_write_wait_s",
         # Special operation wait times
-        "scrub_wait_s",
-        "trim_wait_s",
-        "rebuild_wait_s",
+        "oposs_zpool_scrub_wait_s",
+        "oposs_zpool_trim_wait_s",
+        "oposs_zpool_rebuild_wait_s",
     ],
     optional=[
         # All metrics are optional - graph displays even if some are missing
-        "read_wait_s",
-        "write_wait_s",
-        "disk_read_wait_s",
-        "disk_write_wait_s",
-        "syncq_read_wait_s",
-        "syncq_write_wait_s",
-        "asyncq_read_wait_s",
-        "asyncq_write_wait_s",
-        "scrub_wait_s",
-        "trim_wait_s",
-        "rebuild_wait_s",
+        "oposs_zpool_read_wait_s",
+        "oposs_zpool_write_wait_s",
+        "oposs_zpool_disk_read_wait_s",
+        "oposs_zpool_disk_write_wait_s",
+        "oposs_zpool_syncq_read_wait_s",
+        "oposs_zpool_syncq_write_wait_s",
+        "oposs_zpool_asyncq_read_wait_s",
+        "oposs_zpool_asyncq_write_wait_s",
+        "oposs_zpool_scrub_wait_s",
+        "oposs_zpool_trim_wait_s",
+        "oposs_zpool_rebuild_wait_s",
     ],
     minimal_range=MinimalRange(
         lower=0,
@@ -368,41 +368,41 @@ graph_zpool_queue_depths = Graph(
     title=Title("ZFS Pool Queue Depths"),
     simple_lines=[
         # Sync queue depths
-        "syncq_read_pend",
-        "syncq_read_activ",
-        "syncq_write_pend",
-        "syncq_write_activ",
+        "oposs_zpool_syncq_read_pend",
+        "oposs_zpool_syncq_read_activ",
+        "oposs_zpool_syncq_write_pend",
+        "oposs_zpool_syncq_write_activ",
         # Async queue depths
-        "asyncq_read_pend",
-        "asyncq_read_activ",
-        "asyncq_write_pend",
-        "asyncq_write_activ",
+        "oposs_zpool_asyncq_read_pend",
+        "oposs_zpool_asyncq_read_activ",
+        "oposs_zpool_asyncq_write_pend",
+        "oposs_zpool_asyncq_write_activ",
         # Scrub queue depths  
-        "scrubq_read_pend",
-        "scrubq_read_activ",
+        "oposs_zpool_scrubq_read_pend",
+        "oposs_zpool_scrubq_read_activ",
         # Trim queue depths (will be NaN until agent is updated)
-        "trimq_write_pend",
-        "trimq_write_activ",
+        "oposs_zpool_trimq_write_pend",
+        "oposs_zpool_trimq_write_activ",
         # Rebuild queue depths (will be NaN until agent is updated)
-        "rebuildq_write_pend",
-        "rebuildq_write_activ",
+        "oposs_zpool_rebuildq_write_pend",
+        "oposs_zpool_rebuildq_write_activ",
     ],
     optional=[
         # All metrics are optional - graph displays even if some are missing
-        "syncq_read_pend",
-        "syncq_read_activ",
-        "syncq_write_pend",
-        "syncq_write_activ",
-        "asyncq_read_pend",
-        "asyncq_read_activ",
-        "asyncq_write_pend",
-        "asyncq_write_activ",
-        "scrubq_read_pend",
-        "scrubq_read_activ",
-        "trimq_write_pend",
-        "trimq_write_activ",
-        "rebuildq_write_pend",
-        "rebuildq_write_activ",
+        "oposs_zpool_syncq_read_pend",
+        "oposs_zpool_syncq_read_activ",
+        "oposs_zpool_syncq_write_pend",
+        "oposs_zpool_syncq_write_activ",
+        "oposs_zpool_asyncq_read_pend",
+        "oposs_zpool_asyncq_read_activ",
+        "oposs_zpool_asyncq_write_pend",
+        "oposs_zpool_asyncq_write_activ",
+        "oposs_zpool_scrubq_read_pend",
+        "oposs_zpool_scrubq_read_activ",
+        "oposs_zpool_trimq_write_pend",
+        "oposs_zpool_trimq_write_activ",
+        "oposs_zpool_rebuildq_write_pend",
+        "oposs_zpool_rebuildq_write_activ",
     ],
     minimal_range=MinimalRange(
         lower=0,
@@ -418,8 +418,8 @@ perfometer_zpool_operations = Perfometer(
         upper=Closed(1000),
     ),
     segments=[
-        "read_ops",
-        "write_ops",
+        "oposs_zpool_read_ops",
+        "oposs_zpool_write_ops",
     ],
 )
 
@@ -430,8 +430,8 @@ perfometer_zpool_storage = Perfometer(
         upper=Closed(1000000000000),  # 1TB
     ),
     segments=[
-        "allocated",
-        "free",
+        "oposs_zpool_allocated",
+        "oposs_zpool_free",
     ],
 )
 
@@ -442,8 +442,8 @@ perfometer_zpool_wait_times = Perfometer(
         upper=Closed(0.1),  # 100ms in seconds
     ),
     segments=[
-        "read_wait_s",
-        "write_wait_s",
+        "oposs_zpool_read_wait_s",
+        "oposs_zpool_write_wait_s",
     ],
 )
 
@@ -456,7 +456,7 @@ perfometer_zpool_comprehensive = Stacked(
             lower=Closed(0),
             upper=Closed(1000),
         ),
-        segments=["read_ops", "write_ops"],
+        segments=["oposs_zpool_read_ops", "oposs_zpool_write_ops"],
     ),
     upper=Perfometer(
         name="zpool_storage_upper",
@@ -464,6 +464,6 @@ perfometer_zpool_comprehensive = Stacked(
             lower=Closed(0),
             upper=Closed(1000000000000),  # 1TB
         ),
-        segments=["allocated", "free"],
+        segments=["oposs_zpool_allocated", "oposs_zpool_free"],
     ),
 )


### PR DESCRIPTION
Two issues prevent clean operation on Checkmk 2.5 and 3.0 daily builds:

1. Metric name collisions (cmk-update-config / plugin loading fails):

cmk_addons.plugins.oposs_zpool_iostat.graphing.oposs_zpool_iostat:metric_read_ops:
plug-in 'read_ops' already defined at cmk.plugins.collection.graphing.standalone:metric_read_ops

Checkmk 3.0 ships built-in metrics named read_ops, write_ops, free etc. This extension registers metrics with identical names — a hard error in 3.0 that prevents the whole package from loading.
This resolves https://github.com/oposs/cmk-oposs_zpool_iostat/issues/4

2. cmk-validate-plugins errors (28 validation failures):

Default parameters 'check_default_parameters' specified by CheckPlugin 'oposs_zpool_iostat'
cannot be read by referenced rule spec 'oposs_zpool_iostat':
ValidationMessage(location=['read_ops_levels'], message='Unable to transform value', ...)

The ruleset uses SimpleLevels, whose consumer model is ('fixed', (warn, crit)) or ('no_levels', None) — but check_default_parameters passed plain None for all level parameters.

Fix

Metric collisions (BREAKING)
All metric names are now prefixed with oposs_zpool_:

| old              | new                                              |
|------------------|--------------------------------------------------|
| read_ops         | oposs_zpool_read_ops                             |
| write_ops        | oposs_zpool_write_ops                            |
| allocated / free | oposs_zpool_allocated / oposs_zpool_free         |
| read_wait_s      | oposs_zpool_read_wait_s                          |
| ...              | (all 31 metrics, incl. queue wait/depth metrics) |

- agent_based: yields prefixed metric names; JSON keys in the agent output are unchanged, so the agent plugin itself is untouched
- graphing: all metric_* definitions renamed; graphs, translations and perfometers updated

Validation fix
- check_default_parameters now uses the proper SimpleLevels consumer model (('no_levels', None) instead of plain None)
- new _levels_active() helper in the check function: only ('fixed', (w, c)) activates threshold checking — the truthy tuple ('no_levels', None) was previously misinterpreted as configured levels

Verification

Tested on a Checkmk 2.5 site:
- Zero collisions against all 5676 built-in metric names
- cmk-validate-plugins clean for oposs_zpool_iostat (previously 28 errors)
- Check produces 31 prefixed metrics; with no_levels: metrics only, no Result objects; with fixed levels: WARN/CRIT triggering verified
- cmk -O core reload clean

Note for upgraders

RRD history is keyed by metric name, so historical graphs will not carry over — graphs restart with fresh history after upgrading. Unavoidable when renaming metrics.