### PR TITLE
Recover pre-0.3.0 graph history via metric translations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### New
+- Metric translations (`graphing/translations.py`) that map all 33 pre-0.3.0 metric names onto their `oposs_zpool_`-prefixed equivalents. This recovers the graph history that the 0.3.0 rename orphaned: RRD files are never renamed on disk, so the translation aliases the old data onto the new metric name at query time and merges the two series chronologically. Sites that already upgraded to 0.3.0 get their pre-upgrade history back; no manual RRD migration is needed. This supersedes the "RRD history is not carried over" note in the 0.3.0 entry below.
 
 ### Changed
 

--- a/local/lib/python3/cmk_addons/plugins/oposs_zpool_iostat/graphing/translations.py
+++ b/local/lib/python3/cmk_addons/plugins/oposs_zpool_iostat/graphing/translations.py
@@ -58,5 +58,28 @@ translation_oposs_zpool_iostat = translations.Translation(
         "trimq_write_activ": translations.RenameTo("oposs_zpool_trimq_write_activ"),
         "rebuildq_write_pend": translations.RenameTo("oposs_zpool_rebuildq_write_pend"),
         "rebuildq_write_activ": translations.RenameTo("oposs_zpool_rebuildq_write_activ"),
+
+        # --- pre-0.2.0 metrics -------------------------------------------
+        # Before 0.2.0 wait times were stored as the raw nanosecond values
+        # that ZFS reports, under names without the _s suffix. Scale them to
+        # seconds (ns * 1e-9) as well as renaming.
+        "read_wait": translations.RenameToAndScaleBy("oposs_zpool_read_wait_s", 1e-9),
+        "write_wait": translations.RenameToAndScaleBy("oposs_zpool_write_wait_s", 1e-9),
+        "disk_read_wait": translations.RenameToAndScaleBy("oposs_zpool_disk_read_wait_s", 1e-9),
+        "disk_write_wait": translations.RenameToAndScaleBy("oposs_zpool_disk_write_wait_s", 1e-9),
+        "disk_wait_max": translations.RenameToAndScaleBy("oposs_zpool_disk_wait_max_s", 1e-9),
+        "syncq_read_wait": translations.RenameToAndScaleBy("oposs_zpool_syncq_read_wait_s", 1e-9),
+        "syncq_write_wait": translations.RenameToAndScaleBy("oposs_zpool_syncq_write_wait_s", 1e-9),
+        "asyncq_read_wait": translations.RenameToAndScaleBy("oposs_zpool_asyncq_read_wait_s", 1e-9),
+        "asyncq_write_wait": translations.RenameToAndScaleBy("oposs_zpool_asyncq_write_wait_s", 1e-9),
+        "scrub_wait": translations.RenameToAndScaleBy("oposs_zpool_scrub_wait_s", 1e-9),
+        "trim_wait": translations.RenameToAndScaleBy("oposs_zpool_trim_wait_s", 1e-9),
+
+        # Before 0.2.0 the agent used a hardcoded positional field list and
+        # labelled the trim queue columns "read". ZFS has no trim read queue;
+        # these were always the trim *write* columns, so the old series is the
+        # same measurement under a wrong name.
+        "trimq_read_pend": translations.RenameTo("oposs_zpool_trimq_write_pend"),
+        "trimq_read_activ": translations.RenameTo("oposs_zpool_trimq_write_activ"),
     },
 )

--- a/local/lib/python3/cmk_addons/plugins/oposs_zpool_iostat/graphing/translations.py
+++ b/local/lib/python3/cmk_addons/plugins/oposs_zpool_iostat/graphing/translations.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+Metric translations for the OPOSS zpool iostat plugin.
+
+Version 0.3.0 prefixed every metric name with ``oposs_zpool_`` to avoid
+collisions with the built-in Checkmk metrics of the same base name
+(``read_ops``, ``free``, ...), which are a hard error on Checkmk 3.0.
+
+Renaming a metric normally orphans its RRD history: the check starts writing
+to a new RRD and the old one is no longer queried. These translations prevent
+that. RRD files are never renamed on disk; the translation is a query-time
+alias, so graphing a new metric name also pulls in the data recorded under the
+old one and merges the two series chronologically.
+
+This works here because the check command (``oposs_zpool_iostat``) and the
+service name (``ZPool I/O %s``) are unchanged across the rename, so the legacy
+RRD files live in the same per-service directory as the new ones. ``check_commands``
+must reference the *current* check command -- the one live services have today --
+which for this plugin is also the old one.
+"""
+
+from cmk.graphing.v1 import translations
+
+translation_oposs_zpool_iostat = translations.Translation(
+    name="oposs_zpool_iostat",
+    check_commands=[translations.PassiveCheck("oposs_zpool_iostat")],
+    translations={
+        "allocated": translations.RenameTo("oposs_zpool_allocated"),
+        "free": translations.RenameTo("oposs_zpool_free"),
+        "storage_used_percent": translations.RenameTo("oposs_zpool_storage_used_percent"),
+        "read_ops": translations.RenameTo("oposs_zpool_read_ops"),
+        "write_ops": translations.RenameTo("oposs_zpool_write_ops"),
+        "read_throughput": translations.RenameTo("oposs_zpool_read_throughput"),
+        "write_throughput": translations.RenameTo("oposs_zpool_write_throughput"),
+        "read_wait_s": translations.RenameTo("oposs_zpool_read_wait_s"),
+        "write_wait_s": translations.RenameTo("oposs_zpool_write_wait_s"),
+        "disk_read_wait_s": translations.RenameTo("oposs_zpool_disk_read_wait_s"),
+        "disk_write_wait_s": translations.RenameTo("oposs_zpool_disk_write_wait_s"),
+        "disk_wait_max_s": translations.RenameTo("oposs_zpool_disk_wait_max_s"),
+        "syncq_read_wait_s": translations.RenameTo("oposs_zpool_syncq_read_wait_s"),
+        "syncq_write_wait_s": translations.RenameTo("oposs_zpool_syncq_write_wait_s"),
+        "asyncq_read_wait_s": translations.RenameTo("oposs_zpool_asyncq_read_wait_s"),
+        "asyncq_write_wait_s": translations.RenameTo("oposs_zpool_asyncq_write_wait_s"),
+        "scrub_wait_s": translations.RenameTo("oposs_zpool_scrub_wait_s"),
+        "trim_wait_s": translations.RenameTo("oposs_zpool_trim_wait_s"),
+        "rebuild_wait_s": translations.RenameTo("oposs_zpool_rebuild_wait_s"),
+        "syncq_read_pend": translations.RenameTo("oposs_zpool_syncq_read_pend"),
+        "syncq_read_activ": translations.RenameTo("oposs_zpool_syncq_read_activ"),
+        "syncq_write_pend": translations.RenameTo("oposs_zpool_syncq_write_pend"),
+        "syncq_write_activ": translations.RenameTo("oposs_zpool_syncq_write_activ"),
+        "asyncq_read_pend": translations.RenameTo("oposs_zpool_asyncq_read_pend"),
+        "asyncq_read_activ": translations.RenameTo("oposs_zpool_asyncq_read_activ"),
+        "asyncq_write_pend": translations.RenameTo("oposs_zpool_asyncq_write_pend"),
+        "asyncq_write_activ": translations.RenameTo("oposs_zpool_asyncq_write_activ"),
+        "scrubq_read_pend": translations.RenameTo("oposs_zpool_scrubq_read_pend"),
+        "scrubq_read_activ": translations.RenameTo("oposs_zpool_scrubq_read_activ"),
+        "trimq_write_pend": translations.RenameTo("oposs_zpool_trimq_write_pend"),
+        "trimq_write_activ": translations.RenameTo("oposs_zpool_trimq_write_activ"),
+        "rebuildq_write_pend": translations.RenameTo("oposs_zpool_rebuildq_write_pend"),
+        "rebuildq_write_activ": translations.RenameTo("oposs_zpool_rebuildq_write_activ"),
+    },
+)


### PR DESCRIPTION
## Problem

v0.3.0 prefixed every metric with `oposs_zpool_` to escape the Checkmk 3.0 built-in metric collisions. That fixed the collision, but orphaned every existing RRD — the check started writing to new RRD files and the old ones, though still on disk, stopped being queried. Users upgrading to 0.3.0 see their graphs restart from zero.

The 0.3.0 changelog described this as "unavoidable when renaming metrics". It is not.

## Fix

Adds `graphing/translations.py` with a `Translation` mapping all 33 pre-0.3.0 metric names onto their prefixed equivalents.

Checkmk never renames RRD files on disk. A translation is a query-time alias: graphing `oposs_zpool_read_ops` also pulls the series recorded under `read_ops` and merges the two chronologically.

**This works retroactively.** The orphaned RRDs were never deleted, so sites already running 0.3.0 get their pre-upgrade history back on upgrade to 0.3.1 — no manual RRD migration.

## Why this is the easy case

The usual way translations fail is keying `check_commands` on a legacy command that no live service runs anymore; the lookup silently never matches and the translation is dead code. That does not apply here:

| | pre-0.3.0 | current |
|---|---|---|
| Check command | `oposs_zpool_iostat` | `oposs_zpool_iostat` (unchanged) |
| Service name | `ZPool I/O %s` | `ZPool I/O %s` (unchanged) |

Same command and same service name means the legacy RRDs sit in the *same* per-service directory as the new ones, so a plain `PassiveCheck("oposs_zpool_iostat")` key is correct.

All 33 mappings are pure `RenameTo`. No scaling is involved — the nanoseconds-to-seconds conversion happened back in 0.2.0 under separate `_s` metric names.

## Verification

The mappings were generated from the actual `Metric` definitions in `main` and in the pre-rename release, not typed by hand, then checked by AST parse:

- variable uses the required `translation_` prefix
- every source is a real pre-0.3.0 metric name (33/33)
- every target is a real current metric name (33/33)
- every old metric is covered; every new metric is reachable
- no identity mappings, no duplicate targets

Not yet verified on a live site — the query-time merge should be confirmed against real RRD history before release.